### PR TITLE
Ignore intersection types

### DIFF
--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -19,6 +19,7 @@ use JetBrains\PHPStormStub\PhpStormStubsMap;
 use Roave\BetterReflection\BetterReflection;
 use Roave\BetterReflection\Reflection\ReflectionAttribute;
 use Roave\BetterReflection\Reflection\ReflectionClass;
+use Roave\BetterReflection\Reflection\ReflectionIntersectionType;
 use Roave\BetterReflection\Reflection\ReflectionUnionType;
 use Roave\BetterReflection\Reflector\DefaultReflector;
 use Roave\BetterReflection\Reflector\Exception\IdentifierNotFound;
@@ -319,7 +320,9 @@ final class Installer implements PluginInterface, EventSubscriberInterface
                 }
 
                 $eventTypeHolder = $method->getParameters()[ZERO]->getType();
-                if ($eventTypeHolder instanceof ReflectionUnionType) {
+                if ($eventTypeHolder instanceof ReflectionIntersectionType) {
+                    continue;
+                } elseif ($eventTypeHolder instanceof ReflectionUnionType) {
                     $eventTypes = $eventTypeHolder->getTypes();
                 } else {
                     $eventTypes = [$eventTypeHolder];


### PR DESCRIPTION
Implementing intersection type support would mean we would have to resolve all available implementations of those contracts. This could come in a future release but for now to ensure we don't generate weird configuration we'll ignore it. (This will not change anything on how this package is currently working.)